### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["cdylib"]
 [dependencies]
 libcruby-sys = { git = "https://github.com/tildeio/helix.git", rev = "6265a62c8d8d4ec50ea3958693a02608802ca3be" }
 libc = "0.2.0"
-lazy_static = "0.2.9"
-ordermap = "0.3.0"
+lazy_static = "1"
+indexmap = "1"

--- a/src/attribute_set/mod.rs
+++ b/src/attribute_set/mod.rs
@@ -1,4 +1,4 @@
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 use std::ffi::CString;
 
 use attribute::Attribute;
@@ -9,11 +9,11 @@ mod ruby_glue;
 
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct AttributeSet {
-    attributes: OrderMap<ffi::ID, Attribute>,
+    attributes: IndexMap<ffi::ID, Attribute>,
 }
 
 impl AttributeSet {
-    pub fn new(attributes: OrderMap<ffi::ID, Attribute>) -> Self {
+    pub fn new(attributes: IndexMap<ffi::ID, Attribute>) -> Self {
         Self { attributes }
     }
 
@@ -81,7 +81,7 @@ impl AttributeSet {
     }
 
     fn write_from_user(&mut self, key: ffi::ID, value: ffi::VALUE) {
-        use ordermap::Entry::*;
+        use indexmap::map::Entry::*;
         use std::mem::swap;
 
         match self.attributes.entry(key) {

--- a/src/attribute_set/ruby_glue.rs
+++ b/src/attribute_set/ruby_glue.rs
@@ -1,4 +1,4 @@
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 
 use attribute::Attribute;
 use {ffi, libc};
@@ -110,7 +110,7 @@ extern "C" fn initialize(this: ffi::VALUE, attrs: ffi::VALUE) -> ffi::VALUE {
             value: ffi::VALUE,
             hash_ptr: *mut libc::c_void,
         ) -> ffi::st_retval {
-            let hash_ptr = hash_ptr as *mut OrderMap<ffi::ID, Attribute>;
+            let hash_ptr = hash_ptr as *mut IndexMap<ffi::ID, Attribute>;
             let hash = unsafe { hash_ptr.as_mut().unwrap() };
 
             let id = string_or_symbol_to_id(key);

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -1,4 +1,4 @@
-use ordermap::OrderMap;
+use indexmap::IndexMap;
 
 use attribute::Attribute;
 use attribute_set::AttributeSet;
@@ -9,7 +9,7 @@ mod ruby_glue;
 
 #[derive(Default, Clone)]
 pub struct Builder {
-    uninitialized_attributes: OrderMap<ffi::ID, Attribute>,
+    uninitialized_attributes: IndexMap<ffi::ID, Attribute>,
 }
 
 impl Builder {
@@ -66,7 +66,7 @@ extern "C" fn push_uninitialized_value(
     value: ffi::VALUE,
     hash_ptr: *mut libc::c_void,
 ) -> ffi::st_retval {
-    let hash_ptr = hash_ptr as *mut OrderMap<ffi::ID, Attribute>;
+    let hash_ptr = hash_ptr as *mut IndexMap<ffi::ID, Attribute>;
     let hash = unsafe { hash_ptr.as_mut().unwrap() };
 
     let id = string_or_symbol_to_id(key);
@@ -82,7 +82,7 @@ extern "C" fn push_value(
     value: ffi::VALUE,
     data_ptr: *mut libc::c_void,
 ) -> ffi::st_retval {
-    let data_ptr = data_ptr as *mut OrderMap<ffi::ID, Attribute>;
+    let data_ptr = data_ptr as *mut IndexMap<ffi::ID, Attribute>;
     let hash = unsafe { data_ptr.as_mut().unwrap() };
 
     let id = string_or_symbol_to_id(key);
@@ -106,7 +106,7 @@ extern "C" fn push_attribute(
     value: ffi::VALUE,
     data_ptr: *mut libc::c_void,
 ) -> ffi::st_retval {
-    let data_ptr = data_ptr as *mut OrderMap<ffi::ID, Attribute>;
+    let data_ptr = data_ptr as *mut IndexMap<ffi::ID, Attribute>;
     let hash = unsafe { data_ptr.as_mut().unwrap() };
 
     let id = string_or_symbol_to_id(key);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 extern crate lazy_static;
 extern crate libc;
 extern crate libcruby_sys as ffi;
-extern crate ordermap;
+extern crate indexmap;
 
 macro_rules! cstr {
     ($s:expr) => {


### PR DESCRIPTION
ordemap has been deprecated in favor of indexmap and lazy_static is just
an easy bump.